### PR TITLE
Add TLS support for gRPC service

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ monitoring:
 ssl:
   cert: "./certs/server.cert"
   key: "./certs/server.key"
+  root_cert: "./certs/root.cert"
 protocols:
   http:
     enable: true
@@ -89,6 +90,7 @@ protocols:
     port: 4312
     mocks_dir: "./grpc/mocks"
     protos_dir: "./grpc/protos"
+    grpc_tls: false
 backup:
   enable: false
   cron: "0 * * * *" # Hourly Backup

--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,7 @@ monitoring:
 ssl:
   cert: "./certs/server.cert"
   key: "./certs/server.key"
+  root_cert: "./certs/root.cert"
 protocols:
   http:
     enable: true
@@ -26,6 +27,7 @@ protocols:
     port: 4312
     mocks_dir: "./grpc/mocks"
     protos_dir: "./grpc/protos"
+    grpc_tls: false
   thrift:
     enable: false
     mocks_dir: "./thrift/mocks"

--- a/docs/mocking-gRPC.md
+++ b/docs/mocking-gRPC.md
@@ -13,6 +13,9 @@ If your package name is in the format **com.foo.bar.package**, format your folde
 ```
 ./grpc/mocks/com/foo/bar/package/service_name/method_name.mock
 ```
+## Enabling TLS for gRPC
+
+gRPC service mock runs without TLS by default. TLS can be enabled by setting the `grpc_tls` configuration value to `true`. The server cert and key files will then be read from `cert` and `key` values in `ssl` configuration. You may also add `root_cert` path configuration value to `ssl` configuration to enable client authentication. If no `root_cert` value is defined client authentication is disabled.
 
 ## Creating a gRPC Mock - Unary Or Client Side Streaming
 

--- a/src/ConfigLoader/LoaderInterface.ts
+++ b/src/ConfigLoader/LoaderInterface.ts
@@ -19,7 +19,8 @@ interface MonitoringConfig {
 
 interface SSLConfig {
     cert: string;
-    key: string
+    key: string;
+    root_cert?: string;
 }
 
 interface Protocols {
@@ -37,6 +38,7 @@ interface ProtocolConfig {
     mocks_dir?: string;
     host?: string;
     protos_dir?: string;
+    grpc_tls?: boolean;
 }
 
 interface ThriftProtocolConfig {

--- a/src/ConfigLoader/index.ts
+++ b/src/ConfigLoader/index.ts
@@ -19,7 +19,7 @@ export default class ConfigLoader {
         this.config.loglevel = this.config.loglevel ? this.config.loglevel : 'info';
         this.config.cpus = this.config.cpus ? this.config.cpus : 1;
         this.config.monitoring = this.config.monitoring ? this.config.monitoring : { port: 5555 };
-        this.config.ssl = this.config.ssl ? this.config.ssl : { cert: null, key: null };
+        this.config.ssl = this.config.ssl ? this.config.ssl : { cert: null, key: null, root_cert: null };
         this.config.protocols.http = this.config.protocols.http ? this.config.protocols.http : {
             enable: true,
             mocks_dir: "./mocks",
@@ -40,7 +40,8 @@ export default class ConfigLoader {
             host: "localhost",
             port: 4312,
             mocks_dir: "./grpc/mocks",
-            protos_dir: "./grpc/protos"
+            protos_dir: "./grpc/protos",
+            grpc_tls: false,
         };
         this.config.protocols.thrift = this.config.protocols.thrift ? this.config.protocols.thrift : {
             enable: false,


### PR DESCRIPTION
# Description

I needed to mock a gRPC interface with TLS so I've added basic support
for enabling TLS for gRPC. Maybe this could also be useful for someone else.

This adds a basic TLS support for gRPC service mocks. A new boolean
configuration key `grpc_tls` has been added to the gRPC protocol configuration
which is set to `false` by default. When set to `true` the TLS cert and key
for gRPC service will be loaded from file paths set in `ssl` `cert` and `key`
configuration values. It is also possible to add `root_cert` configuration
value to enable client authentication. By default client authentication is
disabled.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* OS: Windows
* Node version: 16.13.1
* NPM Version: 8.1.2

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] This does not break any existing functionalities
- [x] Any dependent changes have been merged and published in downstream modules
