### PR TITLE
Change the default gRPC host

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ protocols:
     port: 8082
   grpc:
     enable: false
-    host: localhost
+    host: 0.0.0.0
     port: 4312
     mocks_dir: "./grpc/mocks"
     protos_dir: "./grpc/protos"

--- a/config.yml
+++ b/config.yml
@@ -23,7 +23,7 @@ protocols:
     port: 8082
   grpc:
     enable: false
-    host: localhost
+    host: 0.0.0.0
     port: 4312
     mocks_dir: "./grpc/mocks"
     protos_dir: "./grpc/protos"


### PR DESCRIPTION
# Description

When running over a Docker container, the default host configuration `localhost` doesn't work. Otherwise replacing by `0.0.0.0` works fine both locally and inside a container.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?
If you run `docker-compose up --build` and try to execute some gRPC example, like `readTodo`, you get a `14 UNAVAILABLE` response from server. Changing the host from `localhost` to `0.0.0.0` at `config.yml` solve this problem.

**Test Configuration**:
* OS: Ubuntu 20.04.3 LTS
* Node version: 16.13.2
* NPM Version: 8.3.2

# Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] This does not break any existing functionalities
- [X] Any dependent changes have been merged and published in downstream modules
