### PR TITLE
#178 Added an rootPrefix for http-calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ origins:
   - http://localhost:3000
   - http://localhost:3001
   - http://localhost:5000
+rootPathPrefix: /api/v1 # adds a prefix to each call http://localhost:8080/api/v1/<mocks_dir>  
 # ext_helpers: "./custom_handlebar.json"
 ```
 

--- a/bin/camouflage.js
+++ b/bin/camouflage.js
@@ -67,7 +67,7 @@ if (help) {
       `  enable: false`,
       `ext_helpers: "./custom_handlebar.json" # Remove if not needed`,
       `origins:`,
-      `  - http://localhost:3000`,
+      `  - rootPathPrefix: /api/v1 # adds a prefix to each call http://localhost:8080/api/v1/<mocks_dir>`,
       `  - http://localhost:3001`,
       `  - http://localhost:5000`
     ].join("\n")

--- a/config.yml
+++ b/config.yml
@@ -50,6 +50,7 @@ origins:
   - http://localhost:3000
   - http://localhost:3001
   - http://localhost:5000
+# rootPathPrefix: /api/v1 # adds a prefix to each call http://localhost:8080/api/v1/<mocks_dir>
 # ext_helpers: "./custom_handlebar.json"
 # ext_data_source:
 #   pg:

--- a/src/ConfigLoader/LoaderInterface.ts
+++ b/src/ConfigLoader/LoaderInterface.ts
@@ -11,6 +11,7 @@ export interface CamouflageConfig {
     injection: InjectionConfig;
     ext_helpers?: string;
     origins?: string[];
+    rootPathPrefix?: string;
 }
 
 interface MonitoringConfig {

--- a/src/parser/HttpParser.ts
+++ b/src/parser/HttpParser.ts
@@ -18,16 +18,18 @@ export class HttpParser {
   private req: express.Request;
   private mockDir: string;
   private res: express.Response;
+  private rootPathPrefix: string;
   /**
    *
    * @param {express.Request} req Express Request object for current instance of incoming request
    * @param {express.Response} res Express response to be sent to client
    * @param {string} mockDir location of http mocks
    */
-  constructor(req: express.Request, res: express.Response, mockDir: string) {
+  constructor(req: express.Request, res: express.Response, mockDir: string, rootPathPrefix: string) {
     this.req = req;
     this.mockDir = mockDir;
     this.res = res;
+    this.rootPathPrefix = rootPathPrefix;
   }
   /**
    * Finds a closest match dir for an incoming request
@@ -43,6 +45,9 @@ export class HttpParser {
       headers: this.req.headers,
       body: this.req.body,
     };
+    if (this.rootPathPrefix && reqDetails.path.startsWith(this.rootPathPrefix)){
+      reqDetails.path = reqDetails.path.substring(this.rootPathPrefix.length);  
+    }
     const matchedDir = getWildcardPath(reqDetails.path, this.mockDir);
     return matchedDir;
   };

--- a/src/routes/GlobalController.ts
+++ b/src/routes/GlobalController.ts
@@ -8,10 +8,12 @@ import { HttpParser } from "../parser/HttpParser";
 export default class GlobalController {
   private app: express.Application;
   private mocksDir: string;
+  private rootPathPrefix: string;
   constructor(app: express.Application) {
     const config: CamouflageConfig = getLoaderInstance().getConfig()
     this.app = app;
     this.mocksDir = config.protocols.http.mocks_dir;
+    this.rootPathPrefix = config.rootPathPrefix;
     this.register();
   }
   /**
@@ -57,7 +59,7 @@ export default class GlobalController {
     });
   };
   private handler = (req: express.Request, res: express.Response, verb: string) => {
-    const parser = new HttpParser(req, res, this.mocksDir);
+    const parser = new HttpParser(req, res, this.mocksDir, this.rootPathPrefix);
     const mockFile = parser.getMatchedDir() + `/${verb}.mock`;
     parser.getResponse(mockFile);
   };


### PR DESCRIPTION
# Description

Related to #178 I added an option to add a global root-context. 
E.g. without root prefix
```
GET http://localhost:8080/api/v1/products -> maps to folder <mock_dirs>/api/v1/products/GET.mock
```
with root prefix
```
config.yml
rootPathPrefix: /api/v1 

GET http://localhost:8080/api/v1/products -> maps to folder <mock_dirs>/products/GET.mock
```

Fixes #178 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

local execution

# Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] This does not break any existing functionalities
- [ ] Any dependent changes have been merged and published in downstream modules
