### PR TITLE
Validating parameterized paths on the openapi is now supported

### DIFF
--- a/mocks/pets/__/GET.mock
+++ b/mocks/pets/__/GET.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{ "id": 1, "name": "Rabbit" }

--- a/src/validation/OpenApiAdapter.ts
+++ b/src/validation/OpenApiAdapter.ts
@@ -123,20 +123,41 @@ export default class OpenApiAdapter extends ValidationAdapter {
     const currentRoute = this.findRoute(req);
 
     if (currentRoute && currentRoute[method]) {
-      // check response
-      const responseValidator = new OpenAPIResponseValidator(
-        currentRoute[method]
-      );
+      try {
+        // check response
+        const responseValidator = new OpenAPIResponseValidator(
+          currentRoute[method]
+        );
 
-      const result = responseValidator.validateResponse(
-        response.status,
-        JSON.parse(response.body)
-      );
+        const result = responseValidator.validateResponse(
+          response.status,
+          JSON.parse(response.body)
+        );
 
-      if (result?.errors.length > 0) {
-        const error = createHttpError(
-          409,
-          new Error(JSON.stringify(result.errors, null, 2))
+        if (result?.errors.length > 0) {
+          const error = createHttpError(
+            409,
+            new Error(JSON.stringify(result.errors, null, 2))
+          );
+          return {
+            valid: false,
+            error,
+          };
+        }
+      } catch (err) {
+        const error = new createHttpError[500](
+          JSON.stringify(
+            [
+              {
+                path: "schema",
+                errorCode: "type.openapi.error",
+                message: err.message,
+                location: "schema",
+              },
+            ],
+            null,
+            2
+          )
         );
         return {
           valid: false,

--- a/src/validation/OpenApiAdapter.ts
+++ b/src/validation/OpenApiAdapter.ts
@@ -9,35 +9,72 @@ import logger from "../logger";
 import { ValidationAdapter, ValidationResult } from "./ValidationAdapter";
 import type { HttpParserResponse } from "../parser/HttpParser";
 
-const expressifyPath = (path: string) => {
-  /* eslint-disable */
-  const params = path.match(/(\{(?:\{.*\}|[^\{])*\})/g);
-  /* eslint-enable */
-  if (params?.length > 0) {
-    for (let x = 0; x < params.length; x++) {
-      const param = params[x];
-      path = path.replace(param, param.replace("{", ":").replace("}", ""));
-    }
-  }
-  return path;
-};
-
 export default class OpenApiAdapter extends ValidationAdapter {
   private document: OpenAPI.Document;
 
   private findRoute(req: Request) {
     const { paths } = this.document;
-    const route = Object.entries(paths).find(([p]) => {
-      const expressPath = expressifyPath(p);
+    const route = Object.entries(paths).find(([p, v]) => {
+      const expressPath = this.expressifyPath(p);
+      v.url = p; // assign the url
       const url = req.url.split("?")[0];
       return (
         expressPath === req.route.path ||
         expressPath === url ||
         expressPath.slice(0, -1) === url ||
-        expressPath === url.slice(0, -1)
+        expressPath === url.slice(0, -1) ||
+        this.urlMatchesParsedRoute(expressPath, url)
       );
     });
     return route && route[1];
+  }
+
+  private urlMatchesParsedRoute(route: string, url: string) {
+    const routeParts = this.getParts(route);
+    const urlParts = this.getParts(url);
+    const parsedRoute = routeParts.map((part: string, x: number) => {
+      if (part.startsWith(":")) {
+        return urlParts[x];
+      }
+      return part;
+    });
+    const parsedUrl = `/${parsedRoute.join("/")}`;
+    if (parsedUrl === url) {
+      return true;
+    }
+    return false;
+  }
+
+  private extractPathParamsFromRequest(req: Request) {
+    const currentRoute = this.findRoute(req);
+    const routeParts = this.getParts(this.expressifyPath(currentRoute.url));
+    const urlParts = this.getParts(req.url.split("?")[0]);
+    const pathParams: { [k: string]: string } = {};
+    routeParts.forEach((part: string, x: number) => {
+      if (part.startsWith(":")) {
+        pathParams[part.slice(1)] = urlParts[x];
+      }
+    });
+    return pathParams;
+  }
+
+  private expressifyPath(path: string) {
+    /* eslint-disable */
+    const params = path.match(/(\{(?:\{.*\}|[^\{])*\})/g);
+    /* eslint-enable */
+    if (params?.length > 0) {
+      for (let x = 0; x < params.length; x++) {
+        const param = params[x];
+        path = path.replace(param, param.replace("{", ":").replace("}", ""));
+      }
+    }
+    return path;
+  }
+
+  private getParts(url: string) {
+    const parts = url.split("/");
+    parts.shift();
+    return parts;
   }
 
   async load(): Promise<void> {
@@ -67,6 +104,9 @@ export default class OpenApiAdapter extends ValidationAdapter {
       const requestValidator = new OpenAPIRequestValidator(
         currentRoute[method]
       );
+
+      req.params = this.extractPathParamsFromRequest(req);
+
       const result = requestValidator.validateRequest(req);
 
       if (result?.errors.length > 0) {


### PR DESCRIPTION
# Description

Whenever there are parameters in the url like `/pets/{petId}` it was not picked up by the openapi validator.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* OS: OSX
* Node version: 18.4.0
* NPM Version: 8.12.1

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] This does not break any existing functionalities
- [x] Any dependent changes have been merged and published in downstream modules
