### PR TITLE
fix: lazy loading the validation modules #203

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,6 @@ const start = (
   configLoader.validateAndLoad();
   setLoaderInstance(configLoader);
   const config: CamouflageConfig = getLoaderInstance().getConfig();
-  if (config.validation && config.validation.enable) Validation.create(config.validation);
   // Set log level to the configured level from config.yaml
   setLogLevel(config.loglevel);
   logger.debug(JSON.stringify(config, null, 2));

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -4,11 +4,13 @@ import {
   ValidationConfig,
   ValidationSchemaType,
   ValidationSchema,
+  CamouflageConfig,
 } from "../ConfigLoader/LoaderInterface";
 import { HttpParserResponse } from "../parser/HttpParser";
 import logger from "../logger";
 import OpenApiAdapter from "./OpenApiAdapter";
 import { ValidationResult, ValidationAdapter } from "./ValidationAdapter";
+import { getLoaderInstance } from "../ConfigLoader";
 
 export class Validation {
   private static instance: Validation;
@@ -21,6 +23,10 @@ export class Validation {
   }
 
   public static getInstance(): Validation {
+    if (!Validation.instance) {
+      const config: CamouflageConfig = getLoaderInstance().getConfig();
+      return Validation.create(config.validation);
+    }
     return Validation.instance;
   }
 


### PR DESCRIPTION
# Description

The problem was that the instance of the validation wasn't configured correctly when it was turned off in the config.
Now it's lazy loaded and initialised when needed.

Fixes #203

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] This does not break any existing functionalities
- [x] Any dependent changes have been merged and published in downstream modules
