### PR TITLE
feat: state helper

### DIFF
--- a/docs/handlebars.md
+++ b/docs/handlebars.md
@@ -289,6 +289,54 @@ Content-Type: application/json
 
     Enable injection if you understand the potential risks.
 
+## state
+
+Type: Custom Helper
+
+Usage: State helper gets the mocked state value using a key send within the cookie header.
+If no value is found it will use the default context within the block.
+
+For example:
+```json
+{
+    "has_pending_order": {{#state key='has-pending-order'}}false{{/state}},
+    "cart": {{#state key='cart'}}[
+        {"id": 999, "name": "default prod"}
+    ]{{/state}}
+}
+```
+
+To set a value just send cookie with a specific prefix.
+
+```js
+const prefix = "mocked-state";
+const key = "has-pending-order";
+setCookie(`${prefix}-has-pending-order`, 'true');
+setCookie(`${prefix}-cart`, '[{id: 1, name: "prod1"}, {id: 2, name: "prod2"}]');
+```
+
+!!! caution
+    the limit of cookie values in most browsers is 4KB 
+
+### Usage in Cypress 
+
+If you use Camouglage with [Cypress](https://www.cypress.io/) you could add the following custom command to make life easier.
+
+```js
+/**
+* Custom cypress command to set a mocked state
+*/
+Cypress.Commands.add('setState', (key: string, value: unknown) => {
+    cy.setCookie(`mocked-state-${key}`, typeof value === 'string' ? value : JSON.stringify(value));
+});
+```
+
+Then in your tests
+
+```js
+cy.setState('has_pending_order', true);
+cy.setState('cart', [{id: 1, name: "prod1"}, {id: 2, name: "prod2"}]);
+```
 
 ## Inbuilt Helpers
 

--- a/mocks/hello-world/GET.mock
+++ b/mocks/hello-world/GET.mock
@@ -8,7 +8,8 @@ Response-Delay: {{num_between lower=500 upper=600}}
     "greeting": "Hello {{capture from='query' key='name'}}", 
     "phone": {{randomValue length=10 type='NUMERIC'}}, 
     "dateOfBirth": "{{now format='MM/DD/YYYY'}}",
-    "test": "{{randomValue}}" 
+    "test": "{{randomValue}}",
+    "registered": {{#state key='registered'}}false{{/state}}
 }
 {{else}}
 HTTP/1.1 200 OK
@@ -19,7 +20,8 @@ Content-Type: application/json
     "greeting": "Hello World", 
     "phone": {{randomValue length=10 type='NUMERIC'}}, 
     "dateOfBirth": "{{now format='MM/DD/YYYY'}}",
-    "test": "{{randomValue}}" 
+    "test": "{{randomValue}}",
+    "registered": {{#state key='registered'}}true{{/state}}
 }
 {{/if}}
 

--- a/src/handlebar/StateHelper.ts
+++ b/src/handlebar/StateHelper.ts
@@ -1,0 +1,41 @@
+/**
+ * Defines and registers custom handlebar helper - state
+ */
+export class StateHelper {
+  private Handlebars: any;
+  constructor(Handlebars: any) {
+    this.Handlebars = Handlebars;
+  }
+  /**
+   * Registers code helper
+   *
+   * This helper gets the mocked state value using a key send within the cookie header.
+   * If no value is found it will use the default context within the block.
+   *
+   * For example:
+   * ```json
+   * {
+   *     "has_pending_order": {{#state key='has-pending-order'}}false{{/state}}
+   * }
+   * ```
+   *
+   * To set a value just send cookie with a specific prefix .
+   *
+   * ```js
+   * const prefix = "mocked-state";
+   * const key = "has-pending-order";
+   * setCookie(`${prefix}-${key}`, "true");
+   * ```
+   *
+   * WARNING: the limit of cookie values in most browsers is 4KB
+   * @returns {void}
+   */
+  register = () => {
+    this.Handlebars.registerHelper("state", (context: any) => {
+      const cookie = context.data.root.request.headers.cookie;
+      const key = context.hash.key;
+      const value = new RegExp(`mocked-state-${key}=([^;]+)`).exec(cookie);
+      return value ? value[1] : context.fn(this);
+    });
+  };
+}

--- a/src/handlebar/index.ts
+++ b/src/handlebar/index.ts
@@ -20,6 +20,7 @@ import * as Q from 'q';
 import Handlebars from 'handlebars';
 import { AssignHelper } from "./AssignHelper";
 import { ConcatHelper } from "./ConcatHelper";
+import { StateHelper } from "./StateHelper";
 const HandlebarsPromised = promisedHandlebars(Handlebars, { Promise: Q.Promise })
 /**
  * Creates a instance of HandleBarHelper and register each custom helper
@@ -52,6 +53,7 @@ export const registerHandlebars = () => {
     logger.warn("Code Injection is disabled. Helpers such as code, inject, pg, csv and functionalities such as external helpers, will not work.")
   }
   new ProxyHelper(HandlebarsPromised).register();
+  new StateHelper(HandlebarsPromised).register();
   logger.info("Handlebar helpers registration completed");
 };
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. 

State helper gets the mocked state value using a key send within the cookie header.
If no value is found it will use the default context within the block.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Create a mock like this and set a cookie client side

{
    "has_pending_order": {{#state key='has-pending-order'}}false{{/state}},
    "cart": {{#state key='cart'}}[
        {"id": 999, "name": "default prod"}
    ]{{/state}}
}

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] This does not break any existing functionalities
- [x] Any dependent changes have been merged and published in downstream modules
