### PR TITLE
fix: Configure text middleware to use wildcard for matching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,9 +48,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(
   express.text({
-    type: () => {
-      return true;
-    },
+    type: "text/*"
   })
 );
 // Configure express to compress responses - FUTURE IMPROVEMENT - Allow compression options


### PR DESCRIPTION
# Description

This fixes an issue when `multipart/form-data` and other content-types that are not `application/json` or `application/x-www-form-urlencoded` are handled by the `express.text()` middleware. 
This changes the middleware to process only those requests that match `text/*` content-type.

Fixes #232

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`npm test`, `npm pretest:mock`, `npm test:mock`,  `npm test:features` show no signs of errors.

**Test Configuration**:
* OS: MacOS 13.4
* Node version: 20.2.0
* NPM Version: 9.8.1

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] This does not break any existing functionalities
- [x] Any dependent changes have been merged and published in downstream modules
